### PR TITLE
Try all nameservers before failing to resolve a host

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,22 @@
+PATH
+  remote: .
+  specs:
+    em-resolv-replace (1.1.3)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    eventmachine (1.0.8)
+    metaclass (0.0.4)
+    mocha (0.14.0)
+      metaclass (~> 0.0.1)
+    shoulda (2.11.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  em-resolv-replace!
+  eventmachine
+  mocha (= 0.14.0)
+  shoulda (= 2.11.3)

--- a/em-resolv-replace.gemspec
+++ b/em-resolv-replace.gemspec
@@ -32,7 +32,8 @@ Gem::Specification.new do |s|
      "test/test_em-resolv-replace.rb"
   ]
 
-  s.add_development_dependency(%q<shoulda>, [">= 0"])
-  s.add_development_dependency(%q<mocha>, [">= 0"])
+  s.add_development_dependency(%q<eventmachine>, [">= 0"])
+  s.add_development_dependency(%q<shoulda>, ["2.11.3"])
+  s.add_development_dependency(%q<mocha>, ["0.14.0"])
 end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,7 +1,7 @@
 require 'rubygems'
 require 'test/unit'
 require 'shoulda'
-require 'mocha'
+require 'mocha/setup'
 
 require 'em-resolv-replace'
 

--- a/test/test_em-dns-resolver.rb
+++ b/test/test_em-dns-resolver.rb
@@ -1,0 +1,44 @@
+require 'helper'
+
+module EventMachine
+  module DnsResolver
+    MAX_TRIES = 1
+    RETRY_INTERVAL = 1
+  end
+end
+
+class TestEmDnsResolv < Test::Unit::TestCase
+  should "fail if it cannot resolve and address" do
+    port = EventMachine::DnsResolver::Port
+    EventMachine::DnsResolver.stubs(:nameservers).returns([["1.2.3.4", port]])
+
+    EM.run do
+      df = EventMachine::DnsResolver.resolve('www.google.com')
+      df.errback do |error|
+        assert_equal "retries exceeded", error
+        EM.stop
+      end
+    end
+  end
+
+  should "try all the nameservers before failing" do
+    EventMachine::DnsResolver.stubs(:MAX_TRIES).returns(1)
+    EventMachine::DnsResolver.stubs(:RETRY_INTERVAL).returns(1)
+    port = EventMachine::DnsResolver::Port
+    EventMachine::DnsResolver.stubs(:nameservers).returns([
+      ["1.2.3.4", port], ["8.8.8.8", port] ])
+
+    EM.run do
+      df = EventMachine::DnsResolver.resolve('www.google.com')
+      df.callback do |ip|
+        ip = ip.first if ip.kind_of?(Array)
+        assert_match /\d+\.\d+\.\d+\.\d+/, ip
+        EM.stop
+      end
+      df.errback do |error|
+        EM.stop
+        fail error
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi,

we run into an issue where our first `nameserver` entry in the `/etc/resolv.conf` was unreachable and couldn't be used to resolve any hosts.

This pull requests adds the ability to try all the entries into `/etc/resolv.conf` before failing. It also makes the tests runnable again (albeit only on ruby 1.9.3). Unfortunately there was no coverage for the `EM::DnsResolver` module before my changes so I don't know if they are breaking something else.

Cheers!